### PR TITLE
A1 metal mask RTL changes

### DIFF
--- a/rtl/modules/core/rtl/cm7sys.sv
+++ b/rtl/modules/core/rtl/cm7sys.sv
@@ -734,12 +734,37 @@ module cm7sys
 //    assign corecm7pc[31:0]  = {cm7top_IADDR[31:3],3'h0};//cm7top.u_cortexm7.u_top_sys.u_core.u_cm7_dpu.u_dpu_prog_flow.pc_r_ex1[31:1] * 2;
     assign corecm7pc[31:0]  = pcptr;
 
+
+// eco16c:
+//before eco
+/*
     genvar gvi;
     generate
         for( gvi = 0; gvi < PM_COREUSERCNT; gvi++ ) begin: GENCOREUSER
             `theregrn( coreuserreg0[PM_COREUSERCNT-gvi-1] ) <= ( corecm7pc >= coreusermap[gvi].start_addr) & ( corecm7pc < coreusermap[gvi].end_addr);
         end
     endgenerate
+*/
+//after eco
+    genvar gvi;
+    logic [PM_COREUSERCNT-1:0] coreuserreg0pre;
+    // PM_COREUSERCNT = 8 in daric
+
+    generate
+        for( gvi = 1; gvi < PM_COREUSERCNT; gvi++ ) begin: GENCOREUSER
+            assign coreuserreg0pre[PM_COREUSERCNT-gvi-1] = ( corecm7pc >= coreusermap[gvi].start_addr) & ( corecm7pc < coreusermap[gvi].end_addr);
+        end
+    endgenerate
+
+    // all program out of reram will be identified as fw1
+//    assign coreuserreg0pre[7] = (coreuserreg0[6:4] == 0 );
+    assign coreuserreg0pre[7] = ~|coreuserreg0pre[6:4];
+
+    `theregrn( coreuserreg0 ) <= coreuserreg0pre;
+
+
+// end of eco16c
+
 
     `theregrn( coreuserreg1 ) <= coreuserreg0;
     assign coreuser_change = ~(coreuserreg1==coreuserreg0);

--- a/rtl/modules/rrc/rtl/rrc.sv
+++ b/rtl/modules/rrc/rtl/rrc.sv
@@ -271,7 +271,7 @@ module rrc #(
     bit [63:0] trc_regif_dout_s1;
     bit rrcar_suicide;
 
-    ahb_cr #(.A('h00), .DW(32))                 sfr_rrccr       (.cr(rrccr), .hrdata32(), .resetn(coreresetn), .sfrlock(1'b0), .*);
+    ahb_cr_ECO #(.A('h00), .DW(32))                 sfr_rrccr       (.cr(rrccr), .hrdata32(), .resetn(coreresetn), .sfrlock(1'b0), .*);
     ahb_cr #(.A('h04), .DW(5), .IV('h7))        sfr_rrcfd       (.cr(rrcfd), .hrdata32(), .resetn(coreresetn), .sfrlock(1'b0), .*);
     ahb_sr #(.A('h08), .DW(10))                 sfr_rrcsr       (.sr(rrcsr), .hrdata32(), .resetn(coreresetn), .sfrlock(1'b0), .*);
     ahb_fr #(.A('h0C), .DW(5))                  sfr_rrcfr       (.fr(rrcfr), .hrdata32(), .resetn(coreresetn), .sfrlock(1'b0), .*);
@@ -368,7 +368,9 @@ module rrc #(
     assign acram_rdbusy_pre = ahb_read_acram ? 1'b1 :
                                 ahbarray.hready ? 1'b0 : acram_rdbusy;
 
-    assign ahb_read_acram = ahb_array_trans & ahbarray.hsel & !ahbarray.hwrite & (keysel_ahb | datasel_ahb);
+//#eco16e:
+//    assign ahb_read_acram = ahb_array_trans & ahbarray.hsel & !ahbarray.hwrite & (keysel_ahb | datasel_ahb);
+    assign ahb_read_acram = ahb_array_trans & ahbarray.hsel & (keysel_ahb | datasel_ahb);
     assign keysel_ahb = ( ahbarray.haddr[31:16] == PM_KEY_REGION );
     assign datasel_ahb = ( ahbarray.haddr[31:16] == PM_DATA_REGION );
 
@@ -640,8 +642,6 @@ module rrc #(
   //    coreuser    [7]:fw1,    [6]:fw0,            [5]:boot1           [4]:boot0
 
     localparam PM_CODE_REGION_BORDER = 20'h603D_A;
-    localparam PM_CFGD_REGION = {16'h603D,3'b110};
-    localparam PM_CFGK_REGION = {16'h603D,3'b110};
 
     bit [3:0]  userid_c;
     bit vex_mm_reg;
@@ -715,14 +715,18 @@ module rrc #(
                                 ahb_read_flag & scesel & (sce_rd_dis_k | (!sce_sec_op) | (keytype_in != keytype_k)) |
                                 ahb_write_flag & scesel & (sce_wr_dis_k | (!sce_sec_op) | (keytype_in != keytype_k)) |
                                 (!trustkey[akeyid] & (haddr_reg[15:6] != 10'h0))) & data_op & keysel & (userid_k[7:4] != 4'h0);
-    assign key_access_error = key_access_error_pre & rrccr[10];
+//#eco16
+//    assign key_access_error = key_access_error_pre & rrccr[10];
+    assign key_access_error = key_access_error_pre;
 
     assign data_access_error_pre = (((coreuser_in[7:4] & userid_k[7:4])==0) & (ahb_write_flag | ahb_read_flag) |
                                 ahb_read_flag & ((core_rd_dis_d & (cm7sel|vexsel)) | cm7sel&(!pri_op) | vexsel&(!vex_mm_reg)) |
                                 ahb_write_flag & ((core_wr_dis_d & (cm7sel|vexsel)) | cm7sel&(!pri_op) | vexsel&(!vex_mm_reg)) |
                                 ahb_read_flag & scesel & (sce_rd_dis_d | (!(sce_exc_op | sce_sec_op)) | (keytype_in != keytype_d)) |
                                 ahb_write_flag & scesel & (sce_wr_dis_d | (!(sce_exc_op | sce_sec_op)) | (keytype_in != keytype_d)) ) & data_op & datasel & (userid_d[7:4] != 4'h0);
-    assign data_access_error = data_access_error_pre & rrccr[11];
+//#eco16
+//    assign data_access_error = data_access_error_pre & rrccr[11];
+    assign data_access_error = data_access_error_pre;
 
     assign boot0_code_dis = user_code_cfg_boot0[2] & ahb_read_flag & coreuser_in[5] |           //master boot1 read
                                 user_code_cfg_boot0[3] & ahb_write_flag & coreuser_in[5] |      //master boot1 write
@@ -770,11 +774,22 @@ module rrc #(
                                         ahb_write_flag & scesel & (sce_wr_dis_d | (!(sce_exc_op | sce_sec_op)))) & data_op & codesel;
 
     assign code_access_error_pre = (code_access_error_inst |code_access_error_data);
+//#eco16
     assign code_access_error = code_access_error_pre & rrccr[12];
+//    assign code_access_error = code_access_error_pre;
 
     assign info_access_error_pre = (((brdatreg[axi_yadr][255:248] == PM_WRITE_DIS) | cm7sel&(!pri_op) | vexsel&(!vex_mm_reg) | scesel) & ahb_write_flag |
                                     ((brdatreg[axi_yadr][247:240] == PM_READ_DIS) | cm7sel&(!pri_op) | vexsel&(!vex_mm_reg) | scesel) & ahb_read_flag ) & axi_info & data_op;
-    assign info_access_error = info_access_error_pre & rrccr[14];
+//#eco16
+//    assign info_access_error = info_access_error_pre & rrccr[14];
+    assign info_access_error = info_access_error_pre;
+
+
+
+//#eco16, fix PM_CFGK_REGION typo by ignore haddr_reg[13]
+/*
+    localparam PM_CFGD_REGION = {16'h603D,3'b110};
+    localparam PM_CFGK_REGION = {16'h603D,3'b110};
 
     assign cfg_rd_dis = data_cfg_rd_dis[haddr_reg[12:5]] & (haddr_reg[31:13] == PM_CFGD_REGION) |
                             key_cfg_rd_dis[haddr_reg[12:5]] & (haddr_reg[31:13] == PM_CFGK_REGION) ;
@@ -787,7 +802,27 @@ module rrc #(
 
     assign cfg_access_error_pre = (((cfg_rd_dis & (cm7sel|vexsel)) | cfg_prev_dis) & ahb_read_flag |
                                     ((cfg_wr_dis  & (cm7sel|vexsel)) | cfg_prev_dis) & ahb_write_flag ) & data_op;
-    assign cfg_access_error = cfg_access_error_pre & rrccr[13];
+*/
+    localparam PM_CFGD_REGION = {16'h603D,2'b11};
+    localparam PM_CFGK_REGION = {16'h603D,2'b11};
+
+    assign cfg_rd_dis = data_cfg_rd_dis[haddr_reg[12:5]] & (haddr_reg[31:14] == PM_CFGD_REGION) |
+                            key_cfg_rd_dis[haddr_reg[12:5]] & (haddr_reg[31:14] == PM_CFGK_REGION) ;
+
+    assign cfg_wr_dis = data_cfg_wr_dis[haddr_reg[12:5]] & (haddr_reg[31:14] == PM_CFGD_REGION) |
+                            key_cfg_wr_dis[haddr_reg[12:5]] & (haddr_reg[31:14] == PM_CFGK_REGION) ;
+
+    assign cfg_prev_dis = (((!(coreuser_in[5] | coreuser_in[4])) & (cm7sel|vexsel)) | cm7sel&(!pri_op) | vexsel&(!vex_mm_reg) | scesel)
+                             & ((haddr_reg[31:14] == PM_CFGD_REGION) | (haddr_reg[31:14] == PM_CFGK_REGION));
+
+    assign cfg_access_error_pre = (((cfg_rd_dis & (cm7sel|vexsel)) | cfg_prev_dis) & ahb_read_flag |
+                                    ((cfg_wr_dis  & (cm7sel|vexsel)) | cfg_prev_dis) & ahb_write_flag ) & data_op;
+
+
+
+//#eco16
+//    assign cfg_access_error = cfg_access_error_pre & rrccr[13];
+    assign cfg_access_error = cfg_access_error_pre;// & rrccr[13];
 
     assign cmd_user_write_dis = (key_access_error | data_access_error | info_access_error | code_access_error | cfg_access_error) & ahb_write_flag;
     assign cmd_user_read_dis = (key_access_error | data_access_error | info_access_error | code_access_error | cfg_access_error) & ahb_read_flag;
@@ -1100,3 +1135,147 @@ module rrc #(
         );
 
 endmodule : rrc
+
+module ahb_cr_ECO
+#(
+      parameter A=0,
+      parameter AW=12,
+      parameter DW=16,
+      parameter IV=32'h0,
+      parameter SFRCNT=1,
+//      parameter SRMASK=32'h0,               // set write 1 to clr ( for status reg )
+      parameter RMASK=32'hffff_ffff        // read mask to remove undefined bit
+//      parameter REXTMASK=32'h0              // read ext mask
+)(
+        input  logic                          hclk        ,
+        input  logic                          resetn      ,
+        ahbif.slavein                       ahbs        ,
+        input  bit                          sfrlock     ,
+//        input  bit   [AW-1:0]               sfrhaddr    ,
+//        input  bit   [0:SFRCNT-1][DW-1:0]   sfrhrdataext,
+//        input  bit   [0:SFRCNT-1][DW-1:0]   sfrsr       ,
+        output logic [31:0]                 hrdata32    ,
+        output logic [0:SFRCNT-1][DW-1:0]   cr
+);
+
+
+    logic[DW-1:0] hrdata;
+    assign hrdata32 = hrdata | 32'h0;
+
+    ahb_sfr2_ECO #(
+            .AW          ( AW            ),
+            .DW          ( DW            ),
+            .IV          ( IV            ),
+            .SFRCNT      ( SFRCNT        ),
+            .RMASK       ( RMASK         ),      // read mask to remove undefined bit
+            .FRMASK      ( 32'h0         ),      // set write 1 to clr ( for status reg )
+            .SRMASK      ( 32'h0         )       // read ext mask
+         )ahb_sfr(
+            .hclk        (hclk           ),
+            .resetn      (resetn         ),
+            .ahbs        (ahbs           ),
+            .sfrlock     (sfrlock|'0     ),
+            .sfrhaddr    (A[AW-1:0]      ),
+            .sfrsr       ('0             ),
+            .sfrfr       ('0             ),
+            .sfrhrdata   (hrdata         ),
+            .sfrdata     (cr             )
+         );
+
+endmodule
+
+
+
+// ahb_sfr basic
+
+    module ahb_sfr2_ECO #(
+      parameter AW=12,
+      parameter DW=32,
+      parameter [DW-1:0] IV='0,
+      parameter SFRCNT=1,
+      parameter RMASK=32'hffff_ffff,    // read mask to remove undefined bit
+      parameter FRMASK=32'h0,               // set write 1 to clr ( for status reg )
+      parameter SRMASK=32'h0              // read ext mask
+     )(
+        input  logic                          hclk        ,
+        input  logic                          resetn      ,
+        ahbif.slavein                       ahbs        ,
+        input  bit                          sfrlock     ,
+        input  bit   [AW-1:0]               sfrhaddr    ,
+        input  bit   [0:SFRCNT-1][DW-1:0]   sfrsr       ,
+        input  bit   [0:SFRCNT-1][DW-1:0]   sfrfr       ,
+        output logic [DW-1:0]               sfrhrdata   ,
+        output logic [0:SFRCNT-1][DW-1:0]   sfrdata
+     );
+
+  wire  [AW-1:0]         reg_addr;
+  wire                   reg_read_en;
+  wire                   reg_write_en, reg_write_en0;
+  wire  [3:0]            reg_byte_strobe;
+  wire  [31:0]           reg_wdata;
+  wire  [31:0]           reg_rdata;
+
+  ahbs_trans
+   #(.ADDRWIDTH (AW))
+    strans (
+      .hclk         (hclk),
+      .hresetn      (resetn),
+
+      // Input slave port: 32 bit data bus interface
+      .hsels        (ahbs.hsel),
+      .haddrs       (ahbs.haddr[AW-1:0]),
+      .htranss      (ahbs.htrans),
+      .hsizes       (ahbs.hsize),
+      .hwrites      (ahbs.hwrite),
+      .hreadys      (ahbs.hreadym),
+      .hwdatas      (ahbs.hwdata),
+
+      .hreadyouts   (),
+      .hresps       (),
+      .hrdatas      (),
+
+      // Register interface
+      .addr         (reg_addr),
+      .read_en      (reg_read_en),
+      .write_en     (reg_write_en0),
+      .byte_strobe  (reg_byte_strobe),
+      .wdata        (reg_wdata),
+      .rdata        (reg_rdata)
+  );
+
+
+    bit [0:SFRCNT-1][DW-1:0] sfrhrdata0, sfrhrdatas;
+    bit [0:SFRCNT-1][DW-1:0] sfrdatarr;//={SFRCNT{IV}};
+    bit [0:SFRCNT-1][DW-1:0] sfrdatasr;//{SFRCNT{IV}};
+    bit [0:SFRCNT-1]           sfrsel ;
+//    assign ahbrd = ahbs    .psel & ahbs    .penable & ~ahbs    .pwrite;
+    assign reg_write_en = ~sfrlock & reg_write_en0;
+//    bit [DW-1:0]    sIV = IV;
+
+    genvar i;
+    generate
+    for( i = 0; i < SFRCNT; i = i + 1) begin: GenRnd
+        `theregfull( hclk, resetn, sfrdatarr[i], IV ) <= ( sfrsel[i] & reg_write_en ) ? reg_wdata|32'h0000_1000 : sfrdatarr[i];
+        `theregfull( hclk, resetn, sfrdatasr[i], '0 ) <= ( sfrsel[i] & reg_write_en ) ? ( ~reg_wdata & sfrdatasr[i] ) : ( sfrdatasr[i] | sfrfr[i] );
+        assign sfrdata[i] = ~FRMASK & sfrdatarr[i] | FRMASK & sfrdatasr[i];
+        assign sfrsel[i] = ( reg_addr == sfrhaddr[AW-1:0] + 4*i );
+        assign sfrhrdata0[i] = sfrdata[i] & ~SRMASK |  sfrsr[i] & SRMASK;
+        assign sfrhrdatas[i] = reg_read_en & sfrsel[i] ? sfrhrdata0[i] & RMASK : 0;
+    end
+    endgenerate
+
+    assign sfrhrdata = fnsfrhrdata(sfrhrdatas);
+
+    function bit[DW-1:0]    fnsfrhrdata ( bit [0:SFRCNT-1][DW-1:0] fnsfrhrdatas );
+        bit [DW-1:0] fnvalue;
+        int i;
+        fnvalue = 0;
+        for( i = 0; i <  SFRCNT ; i = i + 1) begin
+            fnvalue = fnvalue | fnsfrhrdatas[i];
+        end
+        fnsfrhrdata = fnvalue;
+    endfunction
+
+
+    endmodule
+

--- a/rtl/modules/sysctrl/rtl/cms.sv
+++ b/rtl/modules/sysctrl/rtl/cms.sv
@@ -85,11 +85,16 @@ module cms (
     bit [2:0]       cmspadout;
     bit cmsatpg_reg;
 
-    `theregrn( cmspadregs ) <= { cmspadregs, cmspad };
+//#eco16b:
+//    `theregrn( cmspadregs ) <= { cmspadregs, cmspad };
+//    `theregrn( cmspadregs[0][2]   ) <= 1'b0;
+    `theregrn( cmspadregs[0] ) <= cmspad;
+    `theregrn( cmspadregs[1] ) <= { cmspadregs[0][0:1], 1'b0 };
+
     `theregrn( cmspadlock ) <= ( cmspadcnt == CMSPADCYC );
     `theregrn( cmspadcnt )  <= ( cmspadcnt == CMSPADCYC ) ? cmspadcnt : cmspadcnt+1;
 
-    `theregfull( clk, chipresetn, cmspaderror, '0 ) <= ( cmspadregs[1] != cmspadregs[0] ) & cmspadlock ? 1'b1 : cmspaderror;
+    `theregfull( clk, chipresetn, cmspaderror, '0 ) <= ( cmspadregs[1] != { cmspadregs[0][0:1], 1'b0 } ) & cmspadlock ? 1'b1 : cmspaderror;
 
 //    assign cmspadout = cmspadregs[1];
     `theregrn( cmspadout ) <= ~cmspadlock ? cmspadregs[1] : cmspadout;


### PR DESCRIPTION
Below describes all the code changes and why they were put into place. The only ECO that affects the RV32 operation directly is ECO16a.1, and the flaw this patches is mitigated in virtual memory by Xous since the register in question is blocked from access by untrusted programs thanks to the page level memory protection. This it is belt-and-suspenders hardening.

ECO16a.2 is already compensated for in the baochip-1x bootloader by deprecating the "key" region and using only "data" for storing access controlled keys (thus the firmware interoperates on both -A0 and -A1 steppings without any changes). As a reminder, the only difference between key and data regions is the ability of key region values to be fed into an HMAC algorithm that can unlock further keys; this mechanism is not used in Baochip-1x because it requires managing symmetric key material and thus the only impact of the change is to reduce the effective storage in half, but even so, we still have 2048 slots.

ECO16b does not affect Baochip-1x because the WMS2 function is not broken out on the CSP package and was inaccessible even on -A0 rev. However, removing it at metal mask is further hardening. This change impacts BGA package users (e.g. CB SKUs, not Baochip SKUs).

ECO16c has no impact on the RV32 as it does not generate coreuser signals using the program counter location. Instead, it uses the ASID mapping encoded in the SATP.

ECO16d is also specific to the CM7 and has no impact on the RV32

ECO16e is a fix that is transparent to the firmware.

Since the Baochip-1 secure boot was coded with knowledge of the -A1 metal mask, the same bootloader works on both -A0 and -A1 variants, as designed. Regression testing indicates there are no regressions. Chips with the suffix -WA are -A0 rev and -WB are -A1 rev. One can also determine which chip rev they have by running `audit` in the boot1 shell.

1. ECO16a: Removal of Optional Access Control Enable

Bits [14:10] of the RRCCR register were originally designed as five independent enable switches for access control. The intent was to facilitate basic functional testing in the early project phase. However, these switches lacked locking mechanisms (e.g., write-1-only protection), rendering access control ineffective when active. Therefore, this ECO removes the RRCCR’s control over the access control feature to ensure proper security enforcement.

In the original rtl, file modules/rrc/rtl/rrc.sv : assign key_access_error = key_access_error_pre & rrccr[10]; assign data_access_error = data_access_error_pre & rrccr[11]; assign code_access_error = code_access_error_pre & rrccr[12]; assign cfg_access_error = cfg_access_error_pre & rrccr[13]; assign info_access_error = info_access_error_pre & rrccr[14];

To remove the rrccr:
assign key_access_error = key_access_error_pre; // rrccr[10]; assign data_access_error = data_access_error_pre; // rrccr[11]; assign code_access_error = code_access_error_pre & rrccr[12]; // this is modified in ECO16d assign cfg_access_error = cfg_access_error_pre; // rrccr[13]; assign info_access_error = info_access_error_pre; // rrccr[14];

2. ECO16a: Fixed the access control  issue of key_cfg (0x603D_E000 ~ 0x603D_FFE0) In rrc.sv rtl, the typo for the PM_CFGK_REGION:
localparam PM_CFGD_REGION = {16'h603D,3'b110};
localparam PM_CFGK_REGION = {16'h603D,3'b110};    // should be 3’b111
So the follow functions will lead to wrong protections:
assign cfg_rd_dis = data_cfg_rd_dis[haddr_reg[12:5]] & (haddr_reg[31:13] == PM_CFGD_REGION) |
                        key_cfg_rd_dis[haddr_reg[12:5]] & (haddr_reg[31:13] == PM_CFGK_REGION) ;

assign cfg_wr_dis = data_cfg_wr_dis[haddr_reg[12:5]] & (haddr_reg[31:13] == PM_CFGD_REGION) |
                        key_cfg_wr_dis[haddr_reg[12:5]] & (haddr_reg[31:13] == PM_CFGK_REGION) ;

assign cfg_prev_dis = (((!(coreuser_in[5] | coreuser_in[4])) & (cm7sel|vexsel)) | cm7sel&(!pri_op) | vexsel&(!vex_mm_reg) | scesel)
                         & ((haddr_reg[31:13] == PM_CFGD_REGION) | (haddr_reg[31:13] == PM_CFGK_REGION));

assign cfg_access_error_pre = (((cfg_rd_dis & (cm7sel|vexsel)) | cfg_prev_dis) & ahb_read_flag |
                                ((cfg_wr_dis  & (cm7sel|vexsel)) | cfg_prev_dis) & ahb_write_flag ) & data_op;

By the very limited netlist, we can remove the haddr_reg[13] from these login cone, in which way we:
    • Key/data cfg lock will be same bits in IFR, either lock bit for keycfg/datacfg could lock keycfg/datacfg both together.
Given each lock bit ( in IFR-AC set ) will lock 8 cfg together, and itself can only be locked as a whole IFR item which is 128bit, which related 1k cfgs ( original design ), on the application side, this function is not useful . At this point, we accept the fact after ECO, we probably leave the cfg lock alone.
    • With the ECO, the d/k cfg will be protected mainly by the boot only rule:
        ◦ Vex + boot + mm
        ◦ CM7 + boot + privilege mode

Here’s the modified rtl in rrc.sv
localparam PM_CFGD_REGION = {16'h603D,2'b11};
localparam PM_CFGK_REGION = {16'h603D,2'b11};

assign cfg_rd_dis = data_cfg_rd_dis[haddr_reg[12:5]] & (haddr_reg[31:14] == PM_CFGD_REGION) |
                        key_cfg_rd_dis[haddr_reg[12:5]] & (haddr_reg[31:14] == PM_CFGK_REGION) ;

assign cfg_wr_dis = data_cfg_wr_dis[haddr_reg[12:5]] & (haddr_reg[31:14] == PM_CFGD_REGION) |
                        key_cfg_wr_dis[haddr_reg[12:5]] & (haddr_reg[31:14] == PM_CFGK_REGION) ;

assign cfg_prev_dis = (((!(coreuser_in[5] | coreuser_in[4])) & (cm7sel|vexsel)) | cm7sel&(!pri_op) | vexsel&(!vex_mm_reg) | scesel)
                         & ((haddr_reg[31:14] == PM_CFGD_REGION) | (haddr_reg[31:14] == PM_CFGK_REGION));

assign cfg_access_error_pre = (((cfg_rd_dis & (cm7sel|vexsel)) | cfg_prev_dis) & ahb_read_flag |
                                ((cfg_wr_dis  & (cm7sel|vexsel)) | cfg_prev_dis) & ahb_write_flag ) & data_op;

33 ECO16b: Removed WMS2 function
We Have the WMS2 pad for daric to avoid the unknown risk blocking the bringing up stage to enable the testmode. After the risk clears, we need this ECO to remove the WMS2 pad to avoid potential backdoors.

In cms.sv, the WMS2 pad is one cmspad[2].
    input logic [0:2]       cmspad,
     bit [1:0][0:2]  cmspadregs;
   `theregrn( cmspadregs) <= { cmspadregs, cmspad };
These cmspadregs are sync regs for cmspad, the ECO will be performed by cut the sync registers.
//#eco16b:
//    `theregrn( cmspadregs ) <= { cmspadregs, cmspad };
//    `theregrn( cmspadregs[0][2]   ) <= 1'b0;
    `theregrn( cmspadregs[0] ) <= cmspad;
    `theregrn( cmspadregs[1] ) <= { cmspadregs[0][0:1], 1'b0 };

4. ECO16c: Modify the coreuser generating The code region access control, in A0 design  we missed the gate for the SRAM/TCM program access ReRAM code region.

| source | coreuser | boot0 | boot1 | fw0 | fw1 |
|--------|----------|-------|-------|-----|-----|
| reram  | boot0    | v     | IFR   | IFR | IFR |
| reram  | boot1    | IFR   | v     | IFR | IFR |
| reram  | fw0      | IFR   | IFR   | v   | IFR |
| reram  | fw1      | IFR   | IFR   | IFR | v   |
| sram   | none     | N/A   | N/A   | N/A | N/A |
| tcm    | none     | N/A   | N/A   | N/A | N/A |

The N/A item is no gating.

To fix this issue, we modified the coreuser generating in cm7sys, to force SRAM/TCM code recognized as FW1:
    • FW1 is low level user so can not access IFR/slotcfg.
    • We will also suggest not use FW1 in the application. Or use FW1 but without any slots.
    • With this ECO, SRAM/TCM code will be recognized as FW1, we can limit the permissions by the configure of IFR.

| source | coreuser | boot0 | boot1 | fw0 | fw1 |
|--------|----------|-------|-------|-----|-----|
| reram  | boot0    | v     | IFR   | IFR | IFR |
| reram  | boot1    | IFR   | v     | IFR | IFR |
| reram  | fw0      | IFR   | IFR   | v   | IFR |
| reram  | fw1      | IFR   | IFR   | IFR | v   |
| sram   | fw1      | IFR   | IFR   | IFR | v   |
| tcm    | fw1      | IFR   | IFR   | IFR | v   |

Original code:
genvar gvi;
generate
    for( gvi = 0; gvi < PM_COREUSERCNT; gvi++ ) begin: GENCOREUSER
        `theregrn( coreuserreg0[PM_COREUSERCNT-gvi-1] ) <= ( corecm7pc >= coreusermap[gvi].start_addr) & ( corecm7pc < coreusermap[gvi].end_addr);
    end
endgenerate

Here coreuserreg0[7:0] is determined by the PC pointer of CM7, corecm7pc[31:0].
    • coreuser[7] - fw1
    • coreuser[6] - fw0
    • coreuser[5] - boot1
    • coreuser[4] - boot0
    • coreuser[3] - SRAM
    • coreuser[2] - ReRAM
    • coreuser[1] - dTCM
    • coreuser[0] - iTCM
So when CM7 is running the code in the ReRAM, the coreuser will be 0x14/24/44/84. In SRAM, 0x08.
In TCM, 0x01

ECO code:
genvar gvi;
logic [PM_COREUSERCNT-1:0] coreuserreg0pre;
// PM_COREUSERCNT = 8 in daric

generate
    for( gvi = 1; gvi < PM_COREUSERCNT; gvi++ ) begin: GENCOREUSER
        assign coreuserreg0pre[PM_COREUSERCNT-gvi-1] = ( corecm7pc >= coreusermap[gvi].start_addr) & ( corecm7pc < coreusermap[gvi].end_addr);
    end
endgenerate

// all program out of reram will be identified as fw1
 assign coreuserreg0pre[7] = ~|coreuserreg0pre[6:4];
`theregrn( coreuserreg0 ) <= coreuserreg0pre;

After ECO when CM7 is running the code in the ReRAM, the coreuser will be unchanged  0x14/24/44/84. In SRAM, 0x08 --> 0x88
TCM, 0x01 --> 0x81
They will be identified as FW1.

5. ECO16d: Modify the rrccr[12] into an oneway SFR

ECO16c change caused another new issue for CM7 bootup.
    • CM7 has input port for init value to indicate the bootup code address.
    • This init value are read from IFR, will be within ReRAM. For boot0, it’s 0x6000_0000.
    • But CM7 real PC is zero after boot. And CM7 will read(not fetch) the reset handler vector and stack pointer from 0x6000_0000, and then jump to the reset handler.
    • This will cause "FW1" read "BOOT0" data, and will be blocked if we disable the permission from BOOT0 R/W for FW1.

To work around this, we will modify the rrccr[12]’s behavior.
    • rrccr[12] is one of the engineering option we gonna remove in ECO16a.
    • The default value zero, will disable the code region access control.
    • We will change the behavior of this CR, make it 0->1 one way by any write rrccr SFR operation.
    • In this way system can boot up, and boot0 can write rrccr[12] to 1 immediately after booting. And it will stick to 1 till reset.

6. ECO16e: Fixed bug: read acram for k/d-slots writing operation

All slots cfg are buffered into the rrc.acram, to make the cfg lookup as quick as AMBA’s speed. When CPU/SCE issued a transfer request of a slot via AMBA, will trigger an acram reading operation to lookup the cfg. The bug we found was, writing a slot, did not trigger a new acram lookup, the cfg will keep the old value from the last read slot:
    • If the software(or SCE) read slotA first, then write slotA. This case is ok.
    • If read A first, then write B. The access control will use the cfg of A to check the writing B. This has to be fixed.

In rtl,

assign ahb_read_acram = ahb_array_trans & ahbarray.hsel & !ahbarray.hwrite & (keysel_ahb | datasel_ahb);

We can get the function correct by removing the & !ahbarray.hwrite.